### PR TITLE
enabled ES7 class properties

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["transform-class-properties"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ node_modules
 !.npmignore
 !.travis.yml
 *~
-
+*.iml
 ### App ###
 dist
 .tmp

--- a/app/index.html
+++ b/app/index.html
@@ -47,6 +47,7 @@
         </div>
 
         <div id="demo" class="col-lg-6"></div>
+        <div id="content" class="col-lg-6"></div>
       </div>
 
       <div class="footer">

--- a/app/scripts/AppLayout.js
+++ b/app/scripts/AppLayout.js
@@ -1,0 +1,14 @@
+import Marionette from 'backbone.marionette';
+import layoutTemplate from './templates/layout.hbs';
+
+export default class AppLayout extends Marionette.LayoutView {
+    myProp = 42;
+    constructor(...rest) {
+        super(...rest);
+        console.log('myProp', this.myProp);
+        this.template = layoutTemplate;
+        this.addRegions({
+            content: '#content'
+        });
+    }
+}

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -1,13 +1,17 @@
 import Marionette from 'backbone.marionette';
 import AppLayout from './AppLayout';
 
+import IndexView from './views/IndexView';
+
 var App = new Marionette.Application();
 
 App.on('start', function() {
-  'use strict';
+    'use strict';
 
-  App.rootLayout = new AppLayout({el: '#demo'});
-  App.rootLayout.render();
+    App.rootLayout = new AppLayout({el: 'body'});
+
+    //App.rootLayout.render();
+    App.rootLayout.content.show(new IndexView());
 });
 
 App.start();

--- a/app/scripts/appLayout.js
+++ b/app/scripts/appLayout.js
@@ -1,9 +1,0 @@
-import Marionette from 'backbone.marionette';
-import layoutTemplate from './templates/layout.hbs';
-
-export default class AppLayout extends Marionette.LayoutView {
-  constructor(...rest) {
-    super(...rest);
-    this.template = layoutTemplate;
-  }
-}

--- a/app/scripts/templates/index.hbs
+++ b/app/scripts/templates/index.hbs
@@ -1,0 +1,2 @@
+<h1>Index template</h1>
+Index template contents

--- a/app/scripts/templates/layout.hbs
+++ b/app/scripts/templates/layout.hbs
@@ -1,4 +1,3 @@
-<h4>Hello from Marionette</h4>
-<p>
-  This text is processed with Marionette. If you can see this text then you have installed the app successfully.
-</p>
+<div id="content">
+  content
+</div>

--- a/app/scripts/views/IndexView.js
+++ b/app/scripts/views/IndexView.js
@@ -1,0 +1,16 @@
+import Marionette from 'backbone.marionette';
+import layoutTemplate from '../templates/index.hbs';
+
+import Backbone from 'backbone';
+
+
+export default class IndexView extends Marionette.LayoutView {
+
+  template = layoutTemplate;
+
+  constructor(...rest) {
+    super(...rest);
+
+  }
+
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,9 @@ gulp.task('browserify', function () {
     entries: 'app/scripts/app.js',
     debug: true,
     // defining transforms here will avoid crashing your stream
-    transform: [babelify, hbsfy]
+    transform: [babelify.configure({
+      presets: ["es2015", "stage-0"]
+    }), hbsfy]
   });
 
   bundler = watchify(bundler);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "devDependencies": {
     "autoprefixer": "^6.2.3",
+    "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "babelify": "^7.2.0",
     "browser-sync": "^2.10.1",
     "browserify": "^12.0.1",


### PR DESCRIPTION
This enables class properties that can be used with backbone  and solves incompatibility described here:
http://benmccormick.org/2015/04/07/es6-classes-and-backbone-js/
So you can write in the following way:
`
export default class IndexView extends Marionette.LayoutView {

  template = layoutTemplate;

  constructor(...rest) {
    super(...rest);

  }

}
`
instead of using assigment to this as parent constructor must be called first according to new standart requirements so this makes unavailable to use function-properties and this assigment properly with backbone
